### PR TITLE
Fix delete_tag and maybe other methods

### DIFF
--- a/wallabag_api/wallabag.py
+++ b/wallabag_api/wallabag.py
@@ -76,7 +76,7 @@ class Wallabag(object):
             elif method == 'patch':
                 resp = await self.aio_sess.patch(full_path, data=params)
             elif method == 'delete':
-                resp = await self.aio_sess.delete(full_path, headers=params)
+                resp = await self.aio_sess.delete(full_path, params=params, headers=params)
             elif method == 'put':
                 resp = await self.aio_sess.put(full_path, data=params)
 


### PR DESCRIPTION
The method delete_entries gets the token from the header but the method delete_tag from parameters.
This workaround is ugly but must be fixed in wallabag first.
