### PR TITLE
[FIX] Fix KeyError when a kwargs key is not defined

### DIFF
--- a/wallabag_api/wallabag.py
+++ b/wallabag_api/wallabag.py
@@ -124,9 +124,10 @@ class Wallabag(object):
         :param kwargs:
         :return: value of the parm
         """
-        value = int(kwargs[what]) if type_attr == 'int' else kwargs[what]
-        if what in kwargs and value in value_attr:
-            return value
+        if what in kwargs:
+            value = int(kwargs[what]) if type_attr == 'int' else kwargs[what]
+            if value in value_attr:
+                return value
 
     # ENTRIES
     async def get_entries(self, **kwargs):


### PR DESCRIPTION
In patch_entry() method, if 'star' is not given in kwargs, there is a KeyError in __get_attr() method because we try to retrieve kwargs[what] when 'what' is not in kwargs.